### PR TITLE
Added .env file with Session_Key and deleted hardcoded key from app.rb

### DIFF
--- a/new_app_ruby/Gemfile
+++ b/new_app_ruby/Gemfile
@@ -19,4 +19,8 @@ gem "sqlite3", "~> 1.7"
 # Password hashing
 gem "bcrypt", "~> 3.1"
 
+# In order to use secrets from .env file
+gem "dotenv", "~> 3.1"
+
+
 # YAML er en del af Ruby stdlib, så den behøves ikke at tilføjes som gem

--- a/new_app_ruby/Gemfile.lock
+++ b/new_app_ruby/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     base64 (0.3.0)
     bcrypt (3.1.20)
+    dotenv (3.1.8)
     mini_portile2 (2.8.9)
     multi_json (1.17.0)
     mustermann (3.0.4)
@@ -49,6 +50,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1)
+  dotenv (~> 3.1)
   puma (~> 6.0)
   sinatra (~> 3.2)
   sinatra-contrib (~> 3.2)

--- a/new_app_ruby/app.rb
+++ b/new_app_ruby/app.rb
@@ -6,10 +6,11 @@ require "json"
 require "sqlite3"
 require "bcrypt"
 require "sinatra/flash"
+require "dotenv/load"
 
 configure do
   enable :sessions
-  set :session_secret, "dette_er_ikke_god_maade_at_bruge_secretkey_så_den_skal_aendres_til_en_meget_lang_og_tilfældig_streng_der_er_over_64_bytes_lang" # TODO lav min 64 tegn lang nøgle og gem som miljøvar
+  set :session_secret, ENV.fetch("SESSION_SECRET")
   register Sinatra::Flash
 end
 
@@ -144,9 +145,9 @@ post "/api/login" do
   else
     # Hvis login er succesfuldt
     session[:user_id] = user['id'] # Vi skal bruge sessions her!
-    json(message: "You were logged in", user_id: user['id'])
+    #json(message: "You were logged in", user_id: user['id'])
 
-    redirect '/api/search'
+    redirect '/api/search?q='
   end
 
   if error


### PR DESCRIPTION
Her under udvikling har jeg gemt Session_key i en .env fil, denne er inkluderet i .gitignore, så I skal selv:
- få ruby til at genere en sikker nøgle med kommandoen: ruby -rsecurerandom -e 'puts SecureRandom.hex(64)'
- oprette en .env fil i jeres projekt, hvor nøglen gemmes under SESSION_SECRET=og-så-jeres-meget-lange-nøgle
- der er tilføjet noget til Gemfile, så tror også, at I skal køre bundle install

Vi skal have en key over og ligger på VM som en form for environment variables. 