### PR TITLE
Update .gitignore and enhance local development setup in README and D…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,7 @@ build-iPhoneSimulator/
 
 user_searches.txt
 /.claude/
+
+# Local development files (not for production)
+docker-compose.override.yml
+nginx.local.conf

--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ cd app-whoknows/new_app_ruby
 
 # Configure environment
 cp .env.example .env
-# Edit .env with your settings
 
-# Run with Docker
+# Start containers
 docker compose up -d
+
+# Seed the database (first run only, takes ~3 min)
+docker exec app-whoknows bundle exec rake scrape_sites
 ```
 
 Application available at `http://localhost:80`
+
+> **Local development:** The production nginx uses SSL. See [DEPLOYMENT.md](new_app_ruby/03_DEPLOYMENT.md#first-time-setup-required) for local setup without SSL.
 
 ## Architecture
 


### PR DESCRIPTION
# Pull Request Template 🚀

## Description 📝
Improve local development setup documentation and fix environment configuration issues.

This PR addresses issues encountered when setting up the application locally with Docker Compose:
- Missing `IMAGE_TAG` environment variable causing docker compose to fail
- Nginx requiring SSL certificates that don't exist locally
- Empty database after fresh setup with no clear instructions on how to populate it

**Type of change:**
- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Refactoring 🔄
- [x] Documentation update 📚
- [ ] Other (please specify):

---

## Related Issues 🔗
N/A

---

## How Has This Been Tested? ✅
- Manual testing of local development setup following the updated documentation
- Verified `docker compose up -d` works without errors
- Verified database seeding with `bundle exec rake scrape_sites`
- Confirmed application accessible at http://localhost:80

**Testing Checklist:**
- [x] All tests pass locally
- [ ] New tests added (if applicable)
- [ ] Existing tests updated (if applicable)

---

## Screenshots or Demo (if applicable) 📸
N/A

---

## Checklist 🛠️
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation (if applicable).
- [x] My changes do not introduce new warnings or errors.
- [ ] I have rebased my branch with the latest `dev` branch.

---

## Additional Notes 🗒️
### Changes made:
1. **`.env`** - Added `IMAGE_TAG=latest` 
2. **`docker-compose.yml`** - Restored to use GHCR image for production
3. **`03_DEPLOYMENT.md`** - Added:
   - `IMAGE_TAG` to environment variables table and example
   - First-time setup instructions with `nginx.local.conf` and `docker-compose.override.yml`
   - Database seeding command (`bundle exec rake scrape_sites`)
   - Clear local development workflow

### Local development now requires:
- Creating `nginx.local.conf` (HTTP only, no SSL)
- Creating `docker-compose.override.yml` (overrides nginx volume)
- Both files are gitignored